### PR TITLE
fixed text view bug

### DIFF
--- a/mifospay/src/main/res/layout/activity_signup.xml
+++ b/mifospay/src/main/res/layout/activity_signup.xml
@@ -130,6 +130,8 @@
                     android:gravity="center"
                     android:visibility="gone"
                     android:layout_marginBottom="8dp"
+                    android:paddingBottom="4dp"
+                    android:paddingTop="4dp"
                     android:layout_height="wrap_content" />
                 <android.support.design.widget.TextInputLayout
                     android:id="@+id/etPasswordLayout2"


### PR DESCRIPTION
In Sign Up Xml file text view of id "android:id="@+id/tv_password_strength" which was showing "weak, strong , very strong and password should contain 6 characters " was getting overlapped sometimes with the confirm password edit text or sometime with progress bar just above it.

## Issue Fix
Fixes #{Issue Number}

## Screenshots
<!--Please Add Screenshots or Screen Recordings which show the changes you made.-->

## Description
<!--Please Add Summary of what changes you have made.-->

##
<!--Please make sure these boxes are checked before submitting your pull request - thanks!-->

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
